### PR TITLE
chore: compatibility update

### DIFF
--- a/assistant_skill_analysis/term_analysis/chi2_analyzer.py
+++ b/assistant_skill_analysis/term_analysis/chi2_analyzer.py
@@ -44,7 +44,7 @@ def _compute_chi2_top_feature(
     """
     features_chi2, pval = chi2(features, labels == cls)
 
-    feature_names = np.array(vectorizer.get_feature_names())
+    feature_names = np.array(vectorizer.get_feature_names_out())
 
     features_chi2 = features_chi2[pval < significance_level]
     feature_names = feature_names[pval < significance_level]

--- a/assistant_skill_analysis/term_analysis/keyword_analyzer.py
+++ b/assistant_skill_analysis/term_analysis/keyword_analyzer.py
@@ -38,7 +38,7 @@ def _preprocess_for_heat_map(
                 workspace_df, lang_util=lang_util, unigrams_col_name="unigrams"
             )
 
-    max_n = np.int(
+    max_n = int(
         np.ceil(max_token_display / len(counts.index.get_level_values(0).unique()))
     )
     top_counts = _get_top_n(counts["n_w"], top_n=max_n)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn>=0.21
+scikit-learn~=1.2.2
 numpy>=1.15.1
 pandas
 tabulate

--- a/tests/term_analysis/test_chi2_analyzer.py
+++ b/tests/term_analysis/test_chi2_analyzer.py
@@ -27,7 +27,7 @@ class TestChi2Analyzer(unittest.TestCase):
             test_data, self.lang_util
         )
         self.assertEqual(
-            set(convec.get_feature_names()),
+            set(convec.get_feature_names_out()),
             set(["this", "boston", "this boston"]),
             "Test for chi2 analyzer fail",
         )
@@ -36,7 +36,7 @@ class TestChi2Analyzer(unittest.TestCase):
             self.workspace_df, self.lang_util
         )
         max_len = 0
-        for ngram in convec.get_feature_names():
+        for ngram in convec.get_feature_names_out():
             if len(ngram.split(" ")) > max_len:
                 max_len = len(ngram.split(" "))
         assert max_len <= 2


### PR DESCRIPTION
- change `get_features_name" to  `get_features_name_out`. the original approach is deprecated since sklearn version 1.2.x
- change requirement to be specific for scikit-learn
- update test cases