### PR TITLE
fix: update numpy to 1.21.0 and add numpy 1.26 for newer versions of python

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9"]
+        python-version: ["3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/assistant_skill_analysis/utils/skills_util.py
+++ b/assistant_skill_analysis/utils/skills_util.py
@@ -341,7 +341,7 @@ def run_notebook(
     )
     # nb = _remove_experimentation(nb)
 
-    proc = ExecutePreprocessor(timeout=60 * 60, kernel_name="python3")
+    proc = ExecutePreprocessor(timeout=60 * 60 * 2, kernel_name="python3")
     proc.allow_errors = True
 
     proc.preprocess(nb, {"metadata": {"path": os.getcwd()}})

--- a/assistant_skill_analysis/utils/skills_util.py
+++ b/assistant_skill_analysis/utils/skills_util.py
@@ -341,7 +341,7 @@ def run_notebook(
     )
     # nb = _remove_experimentation(nb)
 
-    proc = ExecutePreprocessor(timeout=60 * 60 * 2, kernel_name="python3")
+    proc = ExecutePreprocessor(timeout=60 * 60, kernel_name="python3")
     proc.allow_errors = True
 
     proc.preprocess(nb, {"metadata": {"path": os.getcwd()}})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 scikit-learn~=1.2.2
-numpy<=1.20.0
+numpy~=1.21.0 ; python_version <= "3.9"
+numpy~=1.26.0 ; python_version > "3.9"
 pandas~=1.4.3
 tabulate
 matplotlib


### PR DESCRIPTION
# Changes
- Numpy version 1.20 has installation problems for M1 Macs
- According to the [release note](https://numpy.org/doc/stable/release/1.21.0-notes.html) 1.21 includes universal wheels for macOS 
- However, 1.21 is only supported for python versions 3.7-3.9, and numpy version 1.26 contains support for > 3.9. [Release note](https://numpy.org/doc/stable/release/1.21.0-notes.html). 
- Support for python 3.9 is maintained, while introducing support for new version of python that customers are using

# Verification
- To verify, I created two conda virtual envs, one with python3.9 and other with python3.10, and verified the successful installation of the dependencies.

